### PR TITLE
Update Minecraft Wiki link to new domain after fork

### DIFF
--- a/latest-version.py
+++ b/latest-version.py
@@ -3,7 +3,12 @@ import urllib.request as ulr
 from bs4 import BeautifulSoup as bs
 
 def main():
-  html = ulr.urlopen('https://minecraft.wiki/w/Bedrock_Dedicated_Server').read()
+  html = ulr.urlopen(
+           ulr.Request(
+             'https://minecraft.wiki/w/Bedrock_Dedicated_Server',
+             headers={'User-Agent': 'Mozilla'}
+           )
+         ).read()
 
   index = -1
   while True:

--- a/latest-version.py
+++ b/latest-version.py
@@ -3,7 +3,7 @@ import urllib.request as ulr
 from bs4 import BeautifulSoup as bs
 
 def main():
-  html = ulr.urlopen('https://minecraft.fandom.com/wiki/Bedrock_Dedicated_Server').read()
+  html = ulr.urlopen('https://minecraft.wiki/w/Bedrock_Dedicated_Server').read()
 
   index = -1
   while True:


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom.