### PR TITLE
Add custom add-on support via /custom-addons mount point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN apt-get update \
 
 RUN chmod +x /bedrock-server/bedrock_server
 
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 WORKDIR /bedrock-server
 ENV LD_LIBRARY_PATH=.
-CMD [ "/bedrock-server/bedrock_server" ]
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -12,3 +12,42 @@ These workflows are chained, so that if the released version of the Bedrock
 Server is updated, the Dockerfile will be updated, the Docker image rebuilt,
 and the webhook invoked. This ensures that a Bedrock Server running off of
 ghcr.io/jasontedor/bedrock-server:latest is always up to date.
+
+## Custom add-ons
+
+You can load custom behavior packs and resource packs by mounting a
+`/custom-addons` volume. The entrypoint script symlinks each pack directory
+into the server's `behavior_packs/` or `resource_packs/` folder at startup,
+so vanilla packs are preserved.
+
+### Expected directory structure
+
+```
+/path/to/addons/
+├── behavior_packs/
+│   └── my_behavior_pack/
+│       └── manifest.json
+└── resource_packs/
+    └── my_resource_pack/
+        └── manifest.json
+```
+
+### Example
+
+```sh
+docker run -d \
+  -v /path/to/addons:/custom-addons:ro \
+  -v /path/to/world:/bedrock-server/worlds \
+  ghcr.io/jasontedor/bedrock-server:latest
+```
+
+### Activating packs in your world
+
+After mounting your packs, activate them by editing the JSON files inside your
+world directory:
+
+- `worlds/<world-name>/world_behavior_packs.json`
+- `worlds/<world-name>/world_resource_packs.json`
+
+Each file is a JSON array of objects with `pack_id` and `version` fields
+matching the values in your pack's `manifest.json`.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Symlink custom add-on packs into the server directories.
+# If /custom-addons is not mounted, this is a no-op.
+
+for pack_type in behavior_packs resource_packs; do
+  src_dir="/custom-addons/${pack_type}"
+  dest_dir="/bedrock-server/${pack_type}"
+  if [ -d "$src_dir" ]; then
+    for pack in "$src_dir"/*/; do
+      # skip if the glob matched nothing
+      [ -d "$pack" ] || continue
+      pack_name="$(basename "$pack")"
+      if [ -e "${dest_dir}/${pack_name}" ]; then
+        echo "WARNING: skipping custom pack '${pack_name}' — already exists in ${pack_type}" >&2
+        continue
+      fi
+      ln -s "$pack" "${dest_dir}/${pack_name}"
+      echo "Linked custom pack '${pack_name}' into ${pack_type}"
+    done
+  fi
+done
+
+exec /bedrock-server/bedrock_server


### PR DESCRIPTION
Add an entrypoint script that symlinks custom behavior packs and resource
packs from an optional /custom-addons volume into the server directories at
startup. This avoids shadowing vanilla packs that would occur with direct
bind-mounts of behavior_packs/ or resource_packs/.